### PR TITLE
Avoid manual linking by utilizing NPM workspaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Cache NPM dependencies
         uses: actions/cache@v2
@@ -26,18 +27,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - run: npm install -g @angular/cli
-      - name: Link ng-s2-commons
-        run: npm link
-        working-directory: libs/ngx-s2-commons
-      - name: Link ngx-s2-ui
-        run: npm link
-        working-directory: libs/ngx-s2-ui
       - name: Install dependencies
-        run: |
-          npm ci
-          npm link @itree/ngx-s2-commons @itree/ngx-s2-ui
+        run:  npm ci
         working-directory: ntis-web
+
       - name: Build
-        run: ng build itree-web
+        run: npm run build itree-web
         working-directory: ntis-web

--- a/ntis-web/package-lock.json
+++ b/ntis-web/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "prototype-app",
       "version": "0.0.0",
+      "workspaces": [
+        "../libs/ngx-s2-ui",
+        "../libs/ngx-s2-commons"
+      ],
       "dependencies": {
         "@angular/animations": "^16.1.3",
         "@angular/cdk": "^16.1.3",
@@ -86,6 +90,32 @@
         "prettier": "^2.8.8",
         "tailwindcss": "^3.3.2",
         "typescript": "~5.1.6"
+      }
+    },
+    "../libs/ngx-s2-commons": {
+      "name": "@itree/ngx-s2-commons",
+      "version": "16.1.3",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@ngx-translate/core": "^15.0.0",
+        "primeng": "^16.0.0"
+      }
+    },
+    "../libs/ngx-s2-ui": {
+      "name": "@itree/ngx-s2-ui",
+      "version": "16.0.3",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": "^16.0.0",
+        "@angular/common": "^16.0.0",
+        "@angular/core": "^16.0.0",
+        "@tailwindcss/container-queries": "^0.1.1",
+        "@tailwindcss/forms": "^0.5.3",
+        "tailwindcss": "^3.3.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -5102,6 +5132,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@itree/ngx-s2-commons": {
+      "resolved": "../libs/ngx-s2-commons",
+      "link": true
+    },
+    "node_modules/@itree/ngx-s2-ui": {
+      "resolved": "../libs/ngx-s2-ui",
+      "link": true
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
@@ -21915,6 +21953,18 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
+    },
+    "@itree/ngx-s2-commons": {
+      "version": "file:../libs/ngx-s2-commons",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@itree/ngx-s2-ui": {
+      "version": "file:../libs/ngx-s2-ui",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.3",

--- a/ntis-web/package.json
+++ b/ntis-web/package.json
@@ -14,6 +14,10 @@
     "e2e": "ng e2e",
     "prepare": "cd ../ && husky install ntis-web/.husky"
   },
+  "workspaces": [
+    "../libs/ngx-s2-ui",
+    "../libs/ngx-s2-commons"
+  ],
   "private": true,
   "dependencies": {
     "@angular/animations": "^16.1.3",


### PR DESCRIPTION
This pull request removes code related to manual linking `@itree/ngx-s2-commons`and  `@itree/ngx-s2-ui` libraries by utilizing NPM workspaces. 